### PR TITLE
Fix for no definitions of elements_path

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,8 +47,13 @@
 
 - name: Set a fact containing paths to DIB elements
   set_fact:
+    os_images_elements_path: "{{ os_images_elements }}"
+  when: os_images_elements_path is undefined
+
+- name: Incorporate git-sourced DIB elements
+  set_fact:
     os_images_elements_path: >
-      {{ os_images_elements_path | default(os_images_elements) +
+      {{ os_images_elements_path +
          [item.local ~ '/' ~ item.elements_path] }}
   with_items: "{{ os_images_git_elements }}"
   when: item.elements_path is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,7 +48,6 @@
 - name: Set a fact containing paths to DIB elements
   set_fact:
     os_images_elements_path: "{{ os_images_elements }}"
-  when: os_images_elements_path is undefined
 
 - name: Incorporate git-sourced DIB elements
   set_fact:


### PR DESCRIPTION
If no git elements have elements_path defined, then os_images_elements_path

does not get defined.  It should be instantiated with a default of the
value of os_images_elements list.