### PR TITLE
Fix for Ansible syntax warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -124,7 +124,7 @@
         disk_format: aki
         filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.vmlinuz"
       with_items: "{{ os_images_list }}"
-      when: "{{ 'baremetal' in item.elements }}"
+      when: '"baremetal" in item.elements'
       register: kernel_result
 
     - name: Upload cloud tenant ramdisk for baremetal images
@@ -138,7 +138,7 @@
         disk_format: ari
         filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.initrd"
       with_items: "{{ os_images_list }}"
-      when: "{{ 'baremetal' in item.elements }}"
+      when: '"baremetal" in item.elements'
       register: ramdisk_result
 
     - name: Upload cloud tenant images


### PR DESCRIPTION
I'm not sure I like this one - for some reason it must be quoted and I don't see the distinction.