### PR TITLE
Reset the python interpreter to the original

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -109,6 +109,10 @@
     - "{{ result.results | map(attribute='rc') | list }}"
 
 - block:
+    - name: Set a fact about the current python interpreter
+      set_fact:
+        old_ansible_python_interpreter: "{{ ansible_python_interpreter | default('/usr/bin/python') }}"
+
     - name: Ensure Ansible uses virtualenv python interpreter
       set_fact:
         ansible_python_interpreter: "{{ os_images_venv }}/bin/python"
@@ -163,6 +167,6 @@
     # possible to unset a variable in Ansible.
     - name: Set a fact to reset the Ansible python interpreter
       set_fact:
-        ansible_python_interpreter: /usr/bin/python
+        ansible_python_interpreter: "{{ old_ansible_python_interpreter }}"
 
   when: os_images_upload | bool


### PR DESCRIPTION
Previously, if the role was used with ansible_python_interpreter set,
the variable would be set to /usr/bin/python at the end of role
execution. This change stores the original interpreter and resets it
appropriately.