### PR TITLE
Force rebuild image and reupload

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ will be replaced with the newly built image if `os_images_upload` is set to `Tru
 must be one of the following strings:
 * `rename`: rename old image to append creation timestamp
 * `overwrite`: remove old image
-Defaults to `rename`
+
+Defaults to `rename`.
 
 
 Dependencies

--- a/README.md
+++ b/README.md
@@ -22,10 +22,28 @@ Defaults to `password`.
 
 `os_images_auth`: OpenStack authentication endpoint and credentials.  For
 example, a dict of the form:
-* `auth_url`: Keystone auth endpoint URL.  Defaults to `OS_AUTH_URL`.
-* `project`: OpenStack tenant/project.  Defaults to `OS_TENANT_NAME`.
-* `username`: OpenStack username.  Defaults to `OS_USERNAME`.
-* `password`: OpenStack password.  Defaults to `OS_PASSWORD`.
+* `auth_url`: Keystone auth endpoint URL.  Defaults to `os_images_auth_env[OS_AUTH_URL]`.
+* `project`: OpenStack tenant/project.  Defaults to `os_images_auth_env[OS_TENANT_NAME]`.
+* `username`: OpenStack username.  Defaults to `os_images_auth_env[OS_USERNAME]`.
+* `password`: OpenStack password.  Defaults to `os_images_auth_env[OS_PASSWORD]`.
+
+`os_images_auth_env`:
+* `OS_PROJECT_DOMAIN_NAME`: Keystone domain name containing the project.
+  Defaults to `"{{ lookup('env', 'OS_PROJECT_DOMAIN_NAME') }}"`
+* `OS_USER_DOMAIN_NAME`: Keystone user's domain name.
+  Defaults to `"{{ lookup('env', 'OS_USER_DOMAIN_NAME') }}"`
+* `OS_PROJECT_NAME`: Keystone project name.
+  Defaults to `"{{ lookup('env', 'OS_PROJECT_NAME') }}"`
+* `OS_USERNAME`: Keystone user name.
+  Defaults to `"{{ lookup('env', 'OS_USERNAME') }}"`
+* `OS_PASSWORD`: Keystone password.
+  Defaults to `"{{ lookup('env', 'OS_PASSWORD') }}"`
+* `OS_AUTH_URL`: Keystone authentication URL.
+  Defaults to `"{{ lookup('env', 'OS_AUTH_URL') }}"`
+* `OS_INTERFACE`: Interface type, can be one of: [admin, public, internal].
+  Defaults to `"{{ lookup('env', 'OS_INTERFACE') }}"`
+* `OS_IDENTITY_API_VERSION`: Keystone identity API version.
+  Defaults to `"{{ lookup('env', 'OS_IDENTITY_API_VERSION') }}"`
 
 `os_images_list` is a list of YAML dicts, where `elements` and `image_url` are
 mutually exclusive where each contain:
@@ -78,6 +96,8 @@ Defaults to `rename`.
 
 Dependencies
 ------------
+
+This has a dependency on `jmespath` as we use the `json_query` filter in the ansible playbooks.
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ following parameters:
 will be replaced with the newly built image if `os_images_upload` is set to `True`. Defaults to
 `False`.
 
+`os_images_overwrite_policy`: What to do when an image with the same name already exists. The value
+must be one of the following strings:
+* `rename`: rename old image to append creation timestamp
+* `overwrite`: remove old image
+Defaults to `rename`
+
+
 Dependencies
 ------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,3 +61,16 @@ os_images_upload: True
 
 # Whether or not the images should be rebuilt if they already exist
 os_images_force_rebuild: False
+
+# What to do when an image with the same name already exists:
+#   - rename: rename old image to append creation timestamp
+#   - overwrite: remove old image
+os_images_overwrite_policy: rename
+
+# Environmental variables for openstack CLI
+openstack_auth_env:
+  OS_PROJECT_NAME: "{{ os_images_auth.project_name }}"
+  OS_USERNAME: "{{ os_images_auth.username }}"
+  OS_PASSWORD: "{{ os_images_auth.password  }}"
+  OS_AUTH_URL: "{{ os_images_auth.auth_url }}"
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,12 @@ os_images_auth_type: password
 #  password:     "{{ lookup('env','OS_PASSWORD') }}"
 #  project_name: "{{ lookup('env','OS_TENANT_NAME') }}"
 os_images_auth:
+  project_domain_name: "{{ os_images_auth_env['OS_PROJECT_DOMAIN_NAME'] }}"
+  user_domain_name: "{{ os_images_auth_env['OS_USER_DOMAIN_NAME'] }}"
+  project_name: "{{ os_images_auth_env['OS_PROJECT_NAME'] }}"
+  username: "{{ os_images_auth_env['OS_USERNAME'] }}"
+  password: "{{ os_images_auth_env['OS_PASSWORD'] }}"
+  auth_url: "{{ os_images_auth_env['OS_AUTH_URL'] }}"
 
 # Pin to a specific version of diskimage-builder if required
 os_images_dib_version:
@@ -68,9 +74,12 @@ os_images_force_rebuild: False
 os_images_overwrite_policy: rename
 
 # Environmental variables for openstack CLI
-openstack_auth_env:
-  OS_PROJECT_NAME: "{{ os_images_auth.project_name }}"
-  OS_USERNAME: "{{ os_images_auth.username }}"
-  OS_PASSWORD: "{{ os_images_auth.password  }}"
-  OS_AUTH_URL: "{{ os_images_auth.auth_url }}"
-
+os_images_auth_env:
+  OS_PROJECT_DOMAIN_NAME: "{{ lookup('env', 'OS_PROJECT_DOMAIN_NAME') }}"
+  OS_USER_DOMAIN_NAME: "{{ lookup('env', 'OS_USER_DOMAIN_NAME') }}"
+  OS_PROJECT_NAME: "{{ lookup('env', 'OS_PROJECT_NAME') }}"
+  OS_USERNAME: "{{ lookup('env', 'OS_USERNAME') }}"
+  OS_PASSWORD: "{{ lookup('env', 'OS_PASSWORD') }}"
+  OS_AUTH_URL: "{{ lookup('env', 'OS_AUTH_URL') }}"
+  OS_INTERFACE: "{{ lookup('env', 'OS_INTERFACE') }}"
+  OS_IDENTITY_API_VERSION: "{{ lookup('env', 'OS_IDENTITY_API_VERSION') }}"

--- a/tasks/delete.yml
+++ b/tasks/delete.yml
@@ -4,7 +4,6 @@
   vars:
     checksum_differs: >-
       {{ glance_metadata[image_key]["checksum"] != local_checksums[checksum_key] }}
-    force_rebuild: "{{ item.force_rebuild | default(os_images_force_rebuild) | bool }}"
   os_image:
     auth_type: "{{ os_images_auth_type }}"
     auth: "{{ os_images_auth }}"
@@ -12,5 +11,5 @@
     state: absent
   when:
     - image_key in glance_metadata
-    - force_rebuild or checksum_differs
+    - checksum_differs
   tags: clean

--- a/tasks/delete.yml
+++ b/tasks/delete.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Ensure existing cloud tenant image does not exist
+  vars:
+    checksum_differs: >-
+      {{ glance_metadata[image_key]["checksum"] != local_checksums[checksum_key] }}
+    force_rebuild: "{{ item.force_rebuild | default(os_images_force_rebuild) | bool }}"
+  os_image:
+    auth_type: "{{ os_images_auth_type }}"
+    auth: "{{ os_images_auth }}"
+    name: "{{ image_key }}"
+    state: absent
+  when:
+    - image_key in glance_metadata
+    - force_rebuild or checksum_differs
+  tags: clean

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -232,37 +232,25 @@
 
     - name: Ensure existing cloud tenant kernel does not exist
       vars:
-        image_key: "{{ item.name ~ '-kernel' }}"
-      os_image:
-        auth_type: "{{ os_images_auth_type }}"
-        auth: "{{ os_images_auth }}"
-        name: "{{ item.name ~ '-kernel' }}"
-        state: absent
-      with_items:
-        - "{{ os_images_list }}"
+        image_key: "{{ item.name }}-kernel"
+        checksum_key: '{{ item.name ~ ".vmlinuz" }}'
+      include_tasks: delete.yml
+      with_items: "{{ os_images_list }}"
       when:
+        - os_images_overwrite_policy == "overwrite"
         - item.elements is defined
         - '"baremetal" in item.elements'
-        - item.force_rebuild | default(os_images_force_rebuild) | bool
-        - os_images_overwrite_policy == "overwrite"
-        - image_key in glance_metadata
-        - glance_metadata[image_key]["checksum"] != local_checksums[item.name ~ '.vmlinuz']
-      tags: clean
 
     - name: Rename old kernel
       vars:
         image_key: "{{ item.name }}-kernel"
-        appendix: "-{{ glance_metadata[image_key].timestamp }}"
-      command: >
-        {{ os_images_venv }}/bin/openstack image set {{ image_key }} --property name={{ image_key ~ appendix}}
-      environment: "{{ os_images_auth_env }}"
+        checksum_key: '{{ item.name ~ ".vmlinuz" }}'
+      include_tasks: rename.yml
       with_items: "{{ os_images_list }}"
-      changed_when: False
       when:
-        - item.force_rebuild | default(os_images_force_rebuild) | bool
         - os_images_overwrite_policy == "rename"
-        - image_key in glance_metadata
-        - glance_metadata[image_key]["checksum"] != local_checksums[item.name ~ ".vmlinuz"]
+        - item.elements is defined
+        - '"baremetal" in item.elements'
 
     - name: Upload cloud tenant kernel for baremetal images
       os_image:
@@ -283,35 +271,24 @@
     - name: Rename old ramdisk
       vars:
         image_key: "{{ item.name }}-ramdisk"
-        appendix: "-{{ glance_metadata[image_key].timestamp }}"
-      command: >
-        {{ os_images_venv }}/bin/openstack image set {{ image_key }} --property name={{ image_key ~ appendix}}
-      environment: "{{ os_images_auth_env }}"
+        checksum_key: '{{ item.name ~ ".initrd" }}'
+      include_tasks: rename.yml
       with_items: "{{ os_images_list }}"
-      changed_when: False
       when:
-        - item.force_rebuild | default(os_images_force_rebuild) | bool
         - os_images_overwrite_policy == "rename"
-        - image_key in glance_metadata
-        - glance_metadata[image_key]["checksum"] != local_checksums[item.name ~ ".initrd"]
+        - item.elements is defined
+        - '"baremetal" in item.elements'
 
     - name: Ensure existing cloud tenant ramdisk does not exist
       vars:
-        image_key: "{{ item.name ~ '-ramdisk' }}"
-      os_image:
-        auth_type: "{{ os_images_auth_type }}"
-        auth: "{{ os_images_auth }}"
-        name: "{{ image_key }}"
-        state: absent
+        image_key: "{{ item.name }}-ramdisk"
+        checksum_key: '{{ item.name ~ ".initrd" }}'
+      include_tasks: delete.yml
       with_items: "{{ os_images_list }}"
       when:
+        - os_images_overwrite_policy == "overwrite"
         - item.elements is defined
         - '"baremetal" in item.elements'
-        - item.force_rebuild | default(os_images_force_rebuild) | bool
-        - os_images_overwrite_policy == "overwrite"
-        - image_key in glance_metadata
-        - glance_metadata[image_key]["checksum"] != local_checksums[item.name ~ '.initrd']
-      tags: clean
 
     - name: Upload cloud tenant ramdisk for baremetal images
       os_image:
@@ -331,36 +308,23 @@
 
     - name: Ensure existing cloud tenant image does not exist
       vars:
-        file_extension: ".{{ item.type | default('qcow2') }}"
         image_key: "{{ item.name }}"
-      os_image:
-        auth_type: "{{ os_images_auth_type }}"
-        auth: "{{ os_images_auth }}"
-        name: "{{ image_key }}"
-        state: absent
+        file_extension: ".{{ item.type | default('qcow2') }}"
+        checksum_key: '{{ item.name ~ file_extension }}'
+      include_tasks: delete.yml
       with_items: "{{ os_images_list }}"
       when:
-        - item.force_rebuild | default(os_images_force_rebuild) | bool
-        - os_images_overwrite_policy == "overwrite"
-        - image_key in glance_metadata
-        - glance_metadata[image_key]["checksum"] != local_checksums[item.name ~ file_extension]
-      tags: clean
+        - os_images_overwrite_policy == "rename"
 
     - name: Rename old image
       vars:
         image_key: "{{ item.name }}"
         file_extension: ".{{ item.type | default('qcow2') }}"
-        appendix: "-{{ glance_metadata[item.name].timestamp }}"
-      command: >
-        {{ os_images_venv }}/bin/openstack image set {{ item.name }} --property name={{ item.name ~ appendix}}
-      environment: "{{ os_images_auth_env }}"
+        checksum_key: '{{ item.name ~ file_extension }}'
+      include_tasks: rename.yml
       with_items: "{{ os_images_list }}"
-      changed_when: False
       when:
-        - item.force_rebuild | default(os_images_force_rebuild) | bool
         - os_images_overwrite_policy == "rename"
-        - image_key in glance_metadata
-        - glance_metadata[image_key]["checksum"] != local_checksums[item.name ~ file_extension]
 
     - name: Upload cloud tenant images
       os_image:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -255,7 +255,7 @@
         appendix: "-{{ glance_metadata[image_key].timestamp }}"
       command: >
         {{ os_images_venv }}/bin/openstack image set {{ image_key }} --property name={{ image_key ~ appendix}}  
-      environment: "{{ openstack_auth_env }}"
+      environment: "{{ os_images_auth_env }}"
       with_items: "{{ os_images_list }}"
       changed_when: False
       when:
@@ -286,7 +286,7 @@
         appendix: "-{{ glance_metadata[image_key].timestamp }}"
       command: >
         {{ os_images_venv }}/bin/openstack image set {{ image_key }} --property name={{ image_key ~ appendix}}  
-      environment: "{{ openstack_auth_env }}"
+      environment: "{{ os_images_auth_env }}"
       with_items: "{{ os_images_list }}"
       changed_when: False
       when:
@@ -327,7 +327,6 @@
       when:
         - item.elements is defined 
         - '"baremetal" in item.elements'
-
       register: ramdisk_result
 
     - name: Ensure existing cloud tenant image does not exist
@@ -337,7 +336,7 @@
       os_image:
         auth_type: "{{ os_images_auth_type }}"
         auth: "{{ os_images_auth }}"
-        name: "{{ item.name }}"
+        name: "{{ image_key }}"
         state: absent
       with_items: "{{ os_images_list }}"
       when:
@@ -354,7 +353,7 @@
         appendix: "-{{ glance_metadata[item.name].timestamp }}"
       command: >
         {{ os_images_venv }}/bin/openstack image set {{ item.name }} --property name={{ item.name ~ appendix}}  
-      environment: "{{ openstack_auth_env }}"
+      environment: "{{ os_images_auth_env }}"
       with_items: "{{ os_images_list }}"
       changed_when: False
       when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -218,6 +218,10 @@
         local_checksums: "{{ local_checksums | default({}) | combine({item.key | basename : item.value | basename })}}"
       with_items: "{{ results | json_query(query) }}"
 
+    - name: Set default value for glance_metadata
+      set_fact:
+        glance_metadata: {}
+
     - name: Set fact containing glance metadata
       vars:
         query: "[*].ansible_facts.openstack_image.{key: name, checksum: checksum, ctime: ctime}"
@@ -314,7 +318,7 @@
       include_tasks: delete.yml
       with_items: "{{ os_images_list }}"
       when:
-        - os_images_overwrite_policy == "rename"
+        - os_images_overwrite_policy == "delete"
 
     - name: Rename old image
       vars:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
   file:
     path: "{{ os_images_cache }}/{{ item.name }}"
     state: absent
-  when: item.force_rebuild | default(os_images_force_rebuild) | bool
+  when: False #item.force_rebuild | default(os_images_force_rebuild) | bool
   with_items: "{{ os_images_list }}"
   tags: clean
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -143,7 +143,10 @@
         image: "{{ item.name ~ '-kernel' }}"
       with_items: "{{ os_images_list }}"
       register: kernel_facts
-
+      when:
+        - item.elements is defined 
+        - '"baremetal" in item.elements'
+      
     - name: Compute the MD5 checksum of the kernel images
       stat:
         path: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.vmlinuz"
@@ -152,7 +155,10 @@
         mime: False
       with_items: "{{ os_images_list }}"
       register: kernel_checksums
-
+      when:
+        - item.elements is defined 
+        - '"baremetal" in item.elements'
+      
     # with ansible >= 2.5 we could use os_image_facts without an image name
     - name: Gather facts about cloud tenant ramdisk images
       os_image_facts:
@@ -161,7 +167,10 @@
         image: "{{ item.name ~ '-ramdisk' }}"
       with_items: "{{ os_images_list }}"
       register: ramdisk_facts
-
+      when:
+        - item.elements is defined 
+        - '"baremetal" in item.elements'
+      
     - name: Compute the MD5 checksum of the ramdisk images
       stat:
         path: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.initrd"
@@ -170,6 +179,9 @@
         mime: False
       with_items: "{{ os_images_list }}"
       register: ramdisk_checksums
+      when:
+        - item.elements is defined 
+        - '"baremetal" in item.elements'
 
     # with ansible >= 2.5 we could use os_image_facts without an image name
     - name: Gather facts about cloud tenant images
@@ -188,6 +200,30 @@
         mime: False
       with_items: "{{ os_images_list }}"
       register: image_checksums
+
+    - name: Set fact containing local checksums
+      vars:
+        query: "[*].stat.{key: path , value: checksum}"
+        results: >
+          {{ (kernel_checksums.results | default([]) + ramdisk_checksums.results | default([]) +
+          image_checksums.results | default([])) }}
+      set_fact:
+        local_checksums: "{{ local_checksums | default({}) | combine({item.key | basename : item.value})}}"
+      with_items: "{{ results | json_query(query) }}"
+
+    - name: debug
+      debug:
+        var: local_checksums
+      
+    - name: Set fact containing glance checksums
+      vars:
+        query: "[*].ansible_facts.openstack_image.{key: name, value: checksum}"
+        results: >
+          {{ (kernel_facts.results | default([]) + ramdisk_facts.results | default([]) +
+          image_facts.results | default([])) }}
+      set_fact:
+        glance_checksums: "{{ glance_checksums | default({}) | combine({item.key: item.value})}}"
+      with_items: "{{ results | json_query(query) }}"
 
     - name: Ensure existing cloud tenant kernel does not exist
       os_image:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -151,9 +151,9 @@
       with_items: "{{ os_images_list }}"
       register: kernel_facts
       when:
-        - item.elements is defined 
+        - item.elements is defined
         - '"baremetal" in item.elements'
-      
+
     - name: Compute the MD5 checksum of the kernel images
       stat:
         path: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.vmlinuz"
@@ -163,9 +163,9 @@
       with_items: "{{ os_images_list }}"
       register: kernel_checksums
       when:
-        - item.elements is defined 
+        - item.elements is defined
         - '"baremetal" in item.elements'
-      
+
     # with ansible >= 2.5 we could use os_image_facts without an image name
     - name: Gather facts about cloud tenant ramdisk images
       os_image_facts:
@@ -175,9 +175,9 @@
       with_items: "{{ os_images_list }}"
       register: ramdisk_facts
       when:
-        - item.elements is defined 
+        - item.elements is defined
         - '"baremetal" in item.elements'
-      
+
     - name: Compute the MD5 checksum of the ramdisk images
       stat:
         path: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.initrd"
@@ -187,7 +187,7 @@
       with_items: "{{ os_images_list }}"
       register: ramdisk_checksums
       when:
-        - item.elements is defined 
+        - item.elements is defined
         - '"baremetal" in item.elements'
 
     # with ansible >= 2.5 we could use os_image_facts without an image name
@@ -217,7 +217,7 @@
       set_fact:
         local_checksums: "{{ local_checksums | default({}) | combine({item.key | basename : item.value | basename })}}"
       with_items: "{{ results | json_query(query) }}"
-      
+
     - name: Set fact containing glance metadata
       vars:
         query: "[*].ansible_facts.openstack_image.{key: name, checksum: checksum, ctime: ctime}"
@@ -241,7 +241,7 @@
       with_items:
         - "{{ os_images_list }}"
       when:
-        - item.elements is defined 
+        - item.elements is defined
         - '"baremetal" in item.elements'
         - item.force_rebuild | default(os_images_force_rebuild) | bool
         - os_images_overwrite_policy == "overwrite"
@@ -254,7 +254,7 @@
         image_key: "{{ item.name }}-kernel"
         appendix: "-{{ glance_metadata[image_key].timestamp }}"
       command: >
-        {{ os_images_venv }}/bin/openstack image set {{ image_key }} --property name={{ image_key ~ appendix}}  
+        {{ os_images_venv }}/bin/openstack image set {{ image_key }} --property name={{ image_key ~ appendix}}
       environment: "{{ os_images_auth_env }}"
       with_items: "{{ os_images_list }}"
       changed_when: False
@@ -276,7 +276,7 @@
         filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.vmlinuz"
       with_items: "{{ os_images_list }}"
       when:
-        - item.elements is defined 
+        - item.elements is defined
         - '"baremetal" in item.elements'
       register: kernel_result
 
@@ -285,7 +285,7 @@
         image_key: "{{ item.name }}-ramdisk"
         appendix: "-{{ glance_metadata[image_key].timestamp }}"
       command: >
-        {{ os_images_venv }}/bin/openstack image set {{ image_key }} --property name={{ image_key ~ appendix}}  
+        {{ os_images_venv }}/bin/openstack image set {{ image_key }} --property name={{ image_key ~ appendix}}
       environment: "{{ os_images_auth_env }}"
       with_items: "{{ os_images_list }}"
       changed_when: False
@@ -305,7 +305,7 @@
         state: absent
       with_items: "{{ os_images_list }}"
       when:
-        - item.elements is defined 
+        - item.elements is defined
         - '"baremetal" in item.elements'
         - item.force_rebuild | default(os_images_force_rebuild) | bool
         - os_images_overwrite_policy == "overwrite"
@@ -325,7 +325,7 @@
         filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.initrd"
       with_items: "{{ os_images_list }}"
       when:
-        - item.elements is defined 
+        - item.elements is defined
         - '"baremetal" in item.elements'
       register: ramdisk_result
 
@@ -352,7 +352,7 @@
         file_extension: ".{{ item.type | default('qcow2') }}"
         appendix: "-{{ glance_metadata[item.name].timestamp }}"
       command: >
-        {{ os_images_venv }}/bin/openstack image set {{ item.name }} --property name={{ item.name ~ appendix}}  
+        {{ os_images_venv }}/bin/openstack image set {{ item.name }} --property name={{ item.name ~ appendix}}
       environment: "{{ os_images_auth_env }}"
       with_items: "{{ os_images_list }}"
       changed_when: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,13 @@
     - "ansible_selinux.status != 'disabled'"
   become: True
 
+- name: Set up openstack cli virtualenv
+  pip:
+    virtualenv: "{{ os_images_venv }}"
+    name:
+      - python-openstackclient
+      - python-glanceclient
+
 - name: Ensure download cache dir exists
   file:
     path: "{{ os_images_cache }}"
@@ -26,7 +33,7 @@
   file:
     path: "{{ os_images_cache }}/{{ item.name }}"
     state: absent
-  when: item.force_rebuild | default(os_images_force_rebuild) | bool
+  when: False #item.force_rebuild | default(os_images_force_rebuild) | bool
   with_items: "{{ os_images_list }}"
   tags: clean
 
@@ -208,40 +215,54 @@
           {{ (kernel_checksums.results | default([]) + ramdisk_checksums.results | default([]) +
           image_checksums.results | default([])) }}
       set_fact:
-        local_checksums: "{{ local_checksums | default({}) | combine({item.key | basename : item.value})}}"
+        local_checksums: "{{ local_checksums | default({}) | combine({item.key | basename : item.value | basename })}}"
       with_items: "{{ results | json_query(query) }}"
-
-    - name: debug
-      debug:
-        var: local_checksums
       
-    - name: Set fact containing glance checksums
+    - name: Set fact containing glance metadata
       vars:
-        query: "[*].ansible_facts.openstack_image.{key: name, value: checksum}"
+        query: "[*].ansible_facts.openstack_image.{key: name, checksum: checksum, ctime: ctime}"
         results: >
           {{ (kernel_facts.results | default([]) + ramdisk_facts.results | default([]) +
           image_facts.results | default([])) }}
       set_fact:
-        glance_checksums: "{{ glance_checksums | default({}) | combine({item.key: item.value})}}"
+        glance_metadata: >
+          {{ glance_metadata | default({}) | combine({item.key: {'checksum': item.checksum,
+          'timestamp': '%Y-%m-%d-%H-%M-%S' | strftime(item.ctime) }}) }}
       with_items: "{{ results | json_query(query) }}"
 
     - name: Ensure existing cloud tenant kernel does not exist
+      vars:
+        image_key: "{{ item.name ~ '-kernel' }}"
       os_image:
         auth_type: "{{ os_images_auth_type }}"
         auth: "{{ os_images_auth }}"
-        name: "{{ item[0].name ~ '-kernel' }}"
+        name: "{{ item.name ~ '-kernel' }}"
         state: absent
-      with_together:
+      with_items:
         - "{{ os_images_list }}"
-        - "{{ kernel_facts.results }}"
-        - "{{ kernel_checksums.results }}"
       when:
-        - item[0].elements is defined 
-        - '"baremetal" in item[0].elements'
-        - item[1].ansible_facts.openstack_image != None
-        - item[1].ansible_facts.openstack_image.checksum != item[2].stat.checksum
+        - item.elements is defined 
+        - '"baremetal" in item.elements'
         - item.force_rebuild | default(os_images_force_rebuild) | bool
+        - os_images_overwrite_policy == "overwrite"
+        - image_key in glance_metadata
+        - glance_metadata[image_key]["checksum"] != local_checksums[item.name ~ '.vmlinuz']
       tags: clean
+
+    - name: Rename old kernel
+      vars:
+        image_key: "{{ item.name }}-kernel"
+        appendix: "-{{ glance_metadata[image_key].timestamp }}"
+      command: >
+        {{ os_images_venv }}/bin/openstack image set {{ image_key }} --property name={{ image_key ~ appendix}}  
+      environment: "{{ openstack_auth_env }}"
+      with_items: "{{ os_images_list }}"
+      changed_when: False
+      when:
+        - item.force_rebuild | default(os_images_force_rebuild) | bool
+        - os_images_overwrite_policy == "rename"
+        - image_key in glance_metadata
+        - glance_metadata[image_key]["checksum"] != local_checksums[item.name ~ ".vmlinuz"]
 
     - name: Upload cloud tenant kernel for baremetal images
       os_image:
@@ -259,17 +280,37 @@
         - '"baremetal" in item.elements'
       register: kernel_result
 
+    - name: Rename old ramdisk
+      vars:
+        image_key: "{{ item.name }}-ramdisk"
+        appendix: "-{{ glance_metadata[image_key].timestamp }}"
+      command: >
+        {{ os_images_venv }}/bin/openstack image set {{ image_key }} --property name={{ image_key ~ appendix}}  
+      environment: "{{ openstack_auth_env }}"
+      with_items: "{{ os_images_list }}"
+      changed_when: False
+      when:
+        - item.force_rebuild | default(os_images_force_rebuild) | bool
+        - os_images_overwrite_policy == "rename"
+        - image_key in glance_metadata
+        - glance_metadata[image_key]["checksum"] != local_checksums[item.name ~ ".initrd"]
+
     - name: Ensure existing cloud tenant ramdisk does not exist
+      vars:
+        image_key: "{{ item.name ~ '-ramdisk' }}"
       os_image:
         auth_type: "{{ os_images_auth_type }}"
         auth: "{{ os_images_auth }}"
-        name: "{{ item.name ~ '-ramdisk' }}"
+        name: "{{ image_key }}"
         state: absent
       with_items: "{{ os_images_list }}"
       when:
         - item.elements is defined 
         - '"baremetal" in item.elements'
         - item.force_rebuild | default(os_images_force_rebuild) | bool
+        - os_images_overwrite_policy == "overwrite"
+        - image_key in glance_metadata
+        - glance_metadata[image_key]["checksum"] != local_checksums[item.name ~ '.initrd']
       tags: clean
 
     - name: Upload cloud tenant ramdisk for baremetal images
@@ -286,17 +327,41 @@
       when:
         - item.elements is defined 
         - '"baremetal" in item.elements'
+
       register: ramdisk_result
 
     - name: Ensure existing cloud tenant image does not exist
+      vars:
+        file_extension: ".{{ item.type | default('qcow2') }}"
+        image_key: "{{ item.name }}"
       os_image:
         auth_type: "{{ os_images_auth_type }}"
         auth: "{{ os_images_auth }}"
         name: "{{ item.name }}"
         state: absent
       with_items: "{{ os_images_list }}"
-      when: item.force_rebuild | default(os_images_force_rebuild) | bool
+      when:
+        - item.force_rebuild | default(os_images_force_rebuild) | bool
+        - os_images_overwrite_policy == "overwrite"
+        - image_key in glance_metadata
+        - glance_metadata[image_key]["checksum"] != local_checksums[item.name ~ file_extension]
       tags: clean
+
+    - name: Rename old image
+      vars:
+        image_key: "{{ item.name }}"
+        file_extension: ".{{ item.type | default('qcow2') }}"
+        appendix: "-{{ glance_metadata[item.name].timestamp }}"
+      command: >
+        {{ os_images_venv }}/bin/openstack image set {{ item.name }} --property name={{ item.name ~ appendix}}  
+      environment: "{{ openstack_auth_env }}"
+      with_items: "{{ os_images_list }}"
+      changed_when: False
+      when:
+        - item.force_rebuild | default(os_images_force_rebuild) | bool
+        - os_images_overwrite_policy == "rename"
+        - image_key in glance_metadata
+        - glance_metadata[image_key]["checksum"] != local_checksums[item.name ~ file_extension]
 
     - name: Upload cloud tenant images
       os_image:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -135,16 +135,75 @@
       set_fact:
         ansible_python_interpreter: "{{ os_images_venv }}/bin/python"
 
+    # with ansible >= 2.5 we could use os_image_facts without an image name
+    - name: Gather facts about cloud tenant kernel images
+      os_image_facts:
+        auth_type: "{{ os_images_auth_type }}"
+        auth: "{{ os_images_auth }}"
+        image: "{{ item.name ~ '-kernel' }}"
+      with_items: "{{ os_images_list }}"
+      register: kernel_facts
+
+    - name: Compute the MD5 checksum of the kernel images
+      stat:
+        path: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.vmlinuz"
+        get_checksum: True
+        checksum_algorithm: md5
+        mime: False
+      with_items: "{{ os_images_list }}"
+      register: kernel_checksums
+
+    # with ansible >= 2.5 we could use os_image_facts without an image name
+    - name: Gather facts about cloud tenant ramdisk images
+      os_image_facts:
+        auth_type: "{{ os_images_auth_type }}"
+        auth: "{{ os_images_auth }}"
+        image: "{{ item.name ~ '-ramdisk' }}"
+      with_items: "{{ os_images_list }}"
+      register: ramdisk_facts
+
+    - name: Compute the MD5 checksum of the ramdisk images
+      stat:
+        path: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.initrd"
+        get_checksum: True
+        checksum_algorithm: md5
+        mime: False
+      with_items: "{{ os_images_list }}"
+      register: ramdisk_checksums
+
+    # with ansible >= 2.5 we could use os_image_facts without an image name
+    - name: Gather facts about cloud tenant images
+      os_image_facts:
+        auth_type: "{{ os_images_auth_type }}"
+        auth: "{{ os_images_auth }}"
+        image: "{{ item.name }}"
+      with_items: "{{ os_images_list }}"
+      register: image_facts
+
+    - name: Compute the MD5 checksum of the images
+      stat:
+        path: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.{{ item.type | default('qcow2') }}"
+        get_checksum: True
+        checksum_algorithm: md5
+        mime: False
+      with_items: "{{ os_images_list }}"
+      register: image_checksums
+
     - name: Ensure existing cloud tenant kernel does not exist
       os_image:
         auth_type: "{{ os_images_auth_type }}"
         auth: "{{ os_images_auth }}"
-        name: "{{ item.name ~ '-kernel' }}"
+        name: "{{ item[0].name ~ '-kernel' }}"
         state: absent
-      with_items: "{{ os_images_list }}"
+      with_together:
+        - "{{ os_images_list }}"
+        - "{{ kernel_facts.results }}"
+        - "{{ kernel_checksums.results }}"
       when:
-        - item.elements is defined 
-        - '"baremetal" in item.elements'
+        - item[0].elements is defined 
+        - '"baremetal" in item[0].elements'
+        - item[1].ansible_facts.openstack_image != None
+        - item[1].ansible_facts.openstack_image.checksum != item[2].stat.checksum
         - item.force_rebuild | default(os_images_force_rebuild) | bool
       tags: clean
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
   file:
     path: "{{ os_images_cache }}/{{ item.name }}"
     state: absent
-  when: False #item.force_rebuild | default(os_images_force_rebuild) | bool
+  when: item.force_rebuild | default(os_images_force_rebuild) | bool
   with_items: "{{ os_images_list }}"
   tags: clean
 

--- a/tasks/rename.yml
+++ b/tasks/rename.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Rename old image
+  vars:
+    appendix: "-{{ glance_metadata[image_key].timestamp }}"
+    checksum_differs: >-
+      {{ glance_metadata[image_key]["checksum"] != local_checksums[checksum_key] }}
+    force_rebuild: item.force_rebuild | default(os_images_force_rebuild) | bool
+  command: >
+    {{ os_images_venv }}/bin/openstack image set {{ image_key }} --property name={{ image_key ~ appendix}}
+  environment: "{{ os_images_auth_env }}"
+  changed_when: False
+  when:
+    - image_key in glance_metadata
+    - force_rebuild or checksum_differs

--- a/tasks/rename.yml
+++ b/tasks/rename.yml
@@ -5,11 +5,10 @@
     appendix: "-{{ glance_metadata[image_key].timestamp }}"
     checksum_differs: >-
       {{ glance_metadata[image_key]["checksum"] != local_checksums[checksum_key] }}
-    force_rebuild: item.force_rebuild | default(os_images_force_rebuild) | bool
   command: >
     {{ os_images_venv }}/bin/openstack image set {{ image_key }} --property name={{ image_key ~ appendix}}
   environment: "{{ os_images_auth_env }}"
   changed_when: False
   when:
     - image_key in glance_metadata
-    - force_rebuild or checksum_differs
+    - checksum_differs


### PR DESCRIPTION
This will only re-upload an image if the checksums differ. You can also choose whether to delete the old image or rename it. The renamed images look like:

```
(os2) [hpcszum2@eod-control images]$ openstack image list
+--------------------------------------+---------------------------------+--------+
| ID                                   | Name                            | Status |
+--------------------------------------+---------------------------------+--------+
| c547a675-8966-4589-b9d4-e27fc2b8ffa5 | CentOS7.5                       | active |
| fc2541e6-f998-42cf-931b-42fe3a5fce42 | CentOS7.5-IB                    | active |
| c3948899-007a-4e65-bddf-e91bb1fb6bf3 | CentOS7.5-OpenHPC               | active |
| 2a116460-13f1-47b7-b5c6-2b0f24e2c396 | delete_me2                      | active |
| 76971079-d2b2-46fe-8be7-18c443958550 | ipa.initramfs                   | active |
| 66f7b5ad-4fc4-4b9a-ae63-daf458ff1f85 | ipa.vmlinuz                     | active |
| b30960d1-a55b-4aeb-be68-2da7d0ea5956 | wjs                             | active |
| 3f83dea2-4468-4a17-bac7-5b7d62225eb6 | wjs-2018-07-06-16-41-29         | active |
| 2c341119-a278-4ee4-8aea-830d03b560d0 | wjs-kernel                      | active |
| b6e9feb3-3f74-4e34-a067-c680f808fb6a | wjs-ramdisk                     | active |
| 726acf96-b17d-4779-b2f8-2d6c4565d3ca | wjs-ramdisk-2018-07-06-16-41-28 | active |
+--------------------------------------+---------------------------------+--------+
```
In the example I was building the wjs image (notice the kernel didn't change).