### PR TITLE
Need root permissions to create image cache directory

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,7 @@
   file:
     path: "{{ os_images_cache }}"
     state: directory
+  become: True
 
 - name: Remove old images for force rebuild
   file:


### PR DESCRIPTION
I found that this task failed:
```
TASK [stackhpc.os-images : Ensure download cache dir exists] **********************************************************************************************************************************************
task path: /home/kayobe/kayobe/src/kayobe/ansible/roles/stackhpc.os-images/tasks/main.yml:20
fatal: [seed-vm]: FAILED! => {"changed": false, "msg": "There was an issue creating /opt/kayobe/images as requested: [Errno 13] Permission denied: '/opt/kayobe/images'", "path": "/opt/kayobe/images", "state": "absent”}
```
so here is a suggested fix.