### PR TITLE
added task to install squashfs-tools

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Install squashfs-tools to provide unsquashfs binary (Debian and RedHat)
+  package:
+    name: squashfs-tools
+    state: present
+
 - name: Set fact containing package needed for qemu-img (debian)
   set_fact:
     qemu_img_pkg: qemu-utils

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   package:
     name: squashfs-tools
     state: present
+  become: True
 
 - name: Set fact containing package needed for qemu-img (debian)
   set_fact:


### PR DESCRIPTION
images failed to build with error message 

```
sudo: unsquashfs: command not found
```

this should fix it for both Debian and RedHat systems (the package name is the same)
