### PR TITLE
Allow customizing interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ example, a dict of the form:
 
 `os_images_cacert` is an optional path to a CA certificate bundle.
 
+`os_images_interface` is the endpoint URL type to fetch from the service
+catalog. Maybe be one of `public`, `admin`, or `internal`.
+
 `os_images_list` is a list of YAML dicts, where `elements` and `image_url` are
 mutually exclusive where each contain:
 * `name`: the image name to use in OpenStack.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,10 @@ os_images_auth_type: password
 #  project_name: "{{ lookup('env','OS_TENANT_NAME') }}"
 os_images_auth:
 
+# Endpoint URL type to fetch from the service catalog. Maybe be one of:
+# public, admin, or internal.
+os_images_interface:
+
 # Pin to a specific version of diskimage-builder if required
 os_images_dib_version:
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -165,6 +165,7 @@
         auth_type: "{{ os_images_auth_type }}"
         auth: "{{ os_images_auth }}"
         cacert: "{{ os_images_cacert | default(omit) }}"
+        interface: "{{ os_images_interface | default(omit, true) }}"
         name: "{{ item.name ~ '-kernel' }}"
         state: absent
       with_items: "{{ os_images_list }}"
@@ -179,6 +180,7 @@
         auth_type: "{{ os_images_auth_type }}"
         auth: "{{ os_images_auth }}"
         cacert: "{{ os_images_cacert | default(omit) }}"
+        interface: "{{ os_images_interface | default(omit, true) }}"
         name: "{{ item.name ~ '-kernel' }}"
         state: present
         is_public: yes
@@ -196,6 +198,7 @@
         auth_type: "{{ os_images_auth_type }}"
         auth: "{{ os_images_auth }}"
         cacert: "{{ os_images_cacert | default(omit) }}"
+        interface: "{{ os_images_interface | default(omit, true) }}"
         name: "{{ item.name ~ '-ramdisk' }}"
         state: absent
       with_items: "{{ os_images_list }}"
@@ -210,6 +213,7 @@
         auth_type: "{{ os_images_auth_type }}"
         auth: "{{ os_images_auth }}"
         cacert: "{{ os_images_cacert | default(omit) }}"
+        interface: "{{ os_images_interface | default(omit, true) }}"
         name: "{{ item.name ~ '-ramdisk' }}"
         state: present
         is_public: yes
@@ -227,6 +231,7 @@
         auth_type: "{{ os_images_auth_type }}"
         auth: "{{ os_images_auth }}"
         cacert: "{{ os_images_cacert | default(omit) }}"
+        interface: "{{ os_images_interface | default(omit, true) }}"
         name: "{{ item.name }}"
         state: absent
       with_items: "{{ os_images_list }}"
@@ -238,6 +243,7 @@
         auth_type: "{{ os_images_auth_type }}"
         auth: "{{ os_images_auth }}"
         cacert: "{{ os_images_cacert | default(omit) }}"
+        interface: "{{ os_images_interface | default(omit, true) }}"
         name: "{{ item.0.name }}"
         state: present
         is_public: yes


### PR DESCRIPTION
Most of the os_ ansible modules take an interface or endpoint_type parameter. This adds interface as a configurable parameter as it is most similar to OS_INTERFACE environment variable.