### PR TITLE
Add support for specifying packages to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ mutually exclusive where each contain:
 * `image_url`: the URL to image location on the Internet.
 * `env`: (optional) environment variables to define for diskimage-builder parameters.
   This is a dict of the form of `KEY: VALUE`.
+* `packages`: (optional) list of packages to install in the image.
 * `size`: (optional) size to make the image filesystem.
 * `properties`: (optional) dict of properties to set on the glance image.
   Common image properties are available

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,8 @@ os_images_common: cloud-init enable-serial-console stable-interface-names
 #       os_distro: centos
 #     env:
 #       DIB_XXX: yyy
+#     packages:
+#       - biosdevname
 #     type: qcow2
 #   - name: FedoraAtomic27
 #     image_url: https://ftp.icm.edu.pl/pub/Linux/dist/fedora-alt/atomic/stable/Fedora-Atomic-27-20180326.1/CloudImages/x86_64/images/Fedora-Atomic-27-20180326.1.x86_64.qcow2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -123,6 +123,7 @@
     dib_args: >-
       {% if item.size is defined %}--image-size {{ item.size }}{% endif %}
       {% if item.type is defined %}-t {{ item.type }}{% endif %}
+      {% if item.packages is defined %}-p {{ item.packages | join(',') }}{% endif %}
       {{ os_images_common }}
       {{ item.elements | join( ' ' ) }}
       -o {{ item.name }}


### PR DESCRIPTION
Diskimage-builder has a -p argument that allows providing a list of packages to be installed in the image. This change exposes it as a 'packages' field in the image list.