### PR TITLE
Fix image build when no packages specified

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -123,7 +123,7 @@
     dib_args: >-
       {% if item.size is defined %}--image-size {{ item.size }}{% endif %}
       {% if item.type is defined %}-t {{ item.type }}{% endif %}
-      {% if item.packages is defined %}-p {{ item.packages | join(',') }}{% endif %}
+      {% if item.packages | default %}-p {{ item.packages | join(',') }}{% endif %}
       {{ os_images_common }}
       {{ item.elements | join( ' ' ) }}
       -o {{ item.name }}


### PR DESCRIPTION
If building an image with no packages specified, the first element in
the list is interpreted as a package. Often this element is the OS
element, in which case the build will fail early. In other cases it may
fail when a package with the name of the first element is not found.

This change fixes the issue by only specifying the -p argument when the
list of packages is defined and non-empty.

Fixes: #26