### PR TITLE
Switch from os-shade to os-openstacksdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - ln -s $(pwd) ../stackhpc.os-images
 
   # Install role dependencies
-  - ansible-galaxy install -p .. stackhpc.os-shade stackhpc.os-openstackclient
+  - ansible-galaxy install -p .. stackhpc.os_openstacksdk stackhpc.os-openstackclient
 
 script:
   # Run Ansible lint against the role

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,10 +23,10 @@ galaxy_info:
     - openstack
 
 dependencies:
-  - role: stackhpc.os-shade
-    os_shade_venv: "{{ os_images_venv }}"
-    os_shade_state: "{{ os_images_package_state }}"
-    os_shade_upper_constraints: "{{ os_images_upper_constraints }}"
+  - role: stackhpc.os_openstacksdk
+    os_openstacksdk_venv: "{{ os_images_venv }}"
+    os_openstacksdk_state: "{{ os_images_package_state }}"
+    os_openstacksdk_upper_constraints: "{{ os_images_upper_constraints }}"
 
   - role: stackhpc.os-openstackclient
     os_openstackclient_venv: "{{ os_images_venv }}"


### PR DESCRIPTION
Shade is no longer required by ansible modules.