### PR TITLE
Use ansible_facts to reference facts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ os_images_package_state: present
 #
 # Use Train upper constraints when running with Python 2, to avoid
 # incompatibility with newer OSC releases.
-os_images_upper_constraints_file: "{% if ansible_python.version.major == 2 %}https://releases.openstack.org/constraints/upper/train{% endif %}"
+os_images_upper_constraints_file: "{% if ansible_facts.python.version.major == 2 %}https://releases.openstack.org/constraints/upper/train{% endif %}"
 
 # Path to a directory in which to cache build artefacts.
 os_images_cache: "{{ lookup('env','HOME') }}/disk_images"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Include OS family-specific variables
-  include_vars: "{{ ansible_os_family }}.yml"
+  include_vars: "{{ ansible_facts.os_family }}.yml"
 
 - name: Ensure required packages are installed
   package:
@@ -11,21 +11,21 @@
 # The rpm-distro element executes 'semanage' during its cleanup phase.
 - name: Ensure diskimage-builder SELinux dependencies are installed
   vars:
-    package_name: "{{ 'policycoreutils-python' if ansible_distribution_major_version | int == 7 else 'python3-policycoreutils' }}"
+    package_name: "{{ 'policycoreutils-python' if ansible_facts.distribution_major_version | int == 7 else 'python3-policycoreutils' }}"
   package:
     name: "{{ package_name }}"
     state: present
   when:
-    - ansible_selinux
-    - "ansible_selinux.status != 'disabled'"
-    - ansible_os_family == "RedHat"
+    - ansible_facts.selinux
+    - "ansible_facts.selinux.status != 'disabled'"
+    - ansible_facts.os_family == "RedHat"
   become: True
 
 - name: Ensure download cache dir exists
   file:
     path: "{{ os_images_cache }}"
-    owner: "{{ ansible_user_uid }}"
-    group: "{{ ansible_user_gid }}"
+    owner: "{{ ansible_facts.user_uid }}"
+    group: "{{ ansible_facts.user_gid }}"
     state: directory
   become: True
 
@@ -40,8 +40,8 @@
 - name: Generate per-image cache directories
   file:
     path: "{{ os_images_cache }}/{{ item.name }}"
-    owner: "{{ ansible_user_uid }}"
-    group: "{{ ansible_user_gid }}"
+    owner: "{{ ansible_facts.user_uid }}"
+    group: "{{ ansible_facts.user_gid }}"
     state: directory
   with_items: "{{ os_images_list }}"
   become: True


### PR DESCRIPTION
By default, Ansible injects a variable for every fact, prefixed with
ansible_. This can result in a large number of variables for each host,
which at scale can incur a performance penalty. Ansible provides a
configuration option [0] that can be set to False to prevent this
injection of facts. In this case, facts should be referenced via
ansible_facts.<fact>.

This change updates all references to Ansible facts from using
individual fact variables to using the items in the
ansible_facts dictionary. This allows users to disable fact variable
injection in their Ansible configuration, which may provide some
performance improvement.

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars