### PR TITLE
Add support to install diskimage-builder from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,19 @@ Defaults to `cloud-init enable-serial-console stable-interface-names`.
 `os_images_dib_version`: Optionally set a version of diskimage-builder to install.
 By default this is not constrained.
 
-`os_images_git_elements`: An optional list of elements to pull from github, deploy
-locally for incorporation into the images.  Supply a list of dicts with the
+`os_images_git_elements`: An optional list of repositories with elements to
+pull from github, deploy locally for incorporation into the images. Optionally
+may contain repository of the diskimage-builder when parameter 
+`diskimage_builder` is set. Supply a list of dicts with the
 following parameters:
 * `repo`: URL to a git repo for cloning (if not already present)
 * `local`: local path for git cloning
 * `version`: optional git reference (branch, tag, hash) for cloning.  Defaults
   to `HEAD`
 * `elements_path`: optional relative path to elements within the repository.
+* `diskimage_builder`: optional flag (true/false) to show that item is the 
+  diskimage-builder repository, and there is need to install diskimage-bulder
+  from source.
 
 `os_images_elements`: An optional list of paths for site-specific DIB elements.
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,6 @@ mutually exclusive where each contain:
 `os_images_common`: A set of elements to include in every image listed.
 Defaults to `cloud-init enable-serial-console stable-interface-names`.
 
-`os_images_dib_pkg_name`: Optionally customise the name parameter passed 
-to the ansible.builtin.pip module when installing diskimage-builder. This can
-be used to install diskimage-builder from version control.
-
 `os_images_dib_version`: Optionally set a version of diskimage-builder to install.
 By default this is not constrained.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,9 +65,6 @@ os_images_interface:
 # Pin to a specific version of diskimage-builder if required
 os_images_dib_version:
 
-# Customise the name parameter passed to the ansible.builtin.pip module.
-os_images_dib_pkg_name: diskimage-builder
-
 # List of git repositories containing site-specific diskimage-builder elements.
 # Each item should be a dict containing 'repo', 'local', and optionally,
 # 'version' items.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,7 +69,7 @@
     virtualenv: "{{ os_images_venv }}"
     extra_args: "{% if os_images_upper_constraints_file %}-c {{ os_images_upper_constraints_file }}{% endif %}"
   with_items:
-    - name: "{{ os_images_dib_pkg_name }}"
+    - name: diskimage-builder
       version: "{{ os_images_dib_version }}"
 
 - name: Git clone any additional image element repos

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,23 +61,58 @@
     image_is_xz: "{{ item.image_url.endswith('.xz') }}"
   when: item.image_url is defined
 
-- name: Install a suitable version of diskimage-builder
+- name: Git clone additional repos
+  git:
+    repo: "{{ item.repo }}"
+    dest: "{{ item.local }}"
+    version: "{{ item.version | default('HEAD') }}"
+  with_items: "{{ os_images_git_elements }}"
+
+- name: Set facts to install diskimage-builder from source
+  set_fact:
+    os_images_dib_git_url: "{{ item.repo }}"
+    os_images_dib_path: "{{ item.local }}"
+  with_items: "{{ os_images_git_elements }}"
+  when: item.diskimage_builder is defined
+
+- name: Install diskimage-builder from source
+  block:
+    - name: Install requirements from diskimage-builder using pip
+      pip:
+        extra_args: "{% if os_images_upper_constraints_file %}-c {{ os_images_upper_constraints_file }}{% endif %}"
+        requirements: "{{ os_images_dib_path }}/requirements.txt"
+        virtualenv: "{{ os_images_venv }}"
+      environment:
+        # NOTE(mmalchuk): https://github.com/pypa/setuptools/issues/2353
+        SETUPTOOLS_USE_DISTUTILS: stdlib
+
+    - name: Install diskimage-builder from source using pip
+      pip:
+        name: "{{ os_images_dib_path }}"
+        virtualenv: "{{ os_images_venv }}"
+      environment:
+        # NOTE(mmalchuk): https://github.com/pypa/setuptools/issues/2353
+        SETUPTOOLS_USE_DISTUTILS: stdlib
+  when:
+    - os_images_dib_git_url is defined
+    - os_images_dib_path is defined
+
+- name: Install diskimage-builder from PyPI
   pip:
     name: "{{ item.name }}"
     version: "{{ item.version or omit }}"
     state: "{{ os_images_package_state }}"
     virtualenv: "{{ os_images_venv }}"
     extra_args: "{% if os_images_upper_constraints_file %}-c {{ os_images_upper_constraints_file }}{% endif %}"
+  environment:
+      # NOTE(mmalchuk): https://github.com/pypa/setuptools/issues/2353
+      SETUPTOOLS_USE_DISTUTILS: stdlib
   with_items:
     - name: diskimage-builder
       version: "{{ os_images_dib_version }}"
-
-- name: Git clone any additional image element repos
-  git:
-    repo: "{{ item.repo }}"
-    dest: "{{ item.local }}"
-    version: "{{ item.version | default('HEAD') }}"
-  with_items: "{{ os_images_git_elements }}"
+  when:
+    - os_images_dib_git_url is undefined
+    - os_images_dib_path is undefined
 
 - name: Set a fact containing paths to DIB elements
   set_fact:


### PR DESCRIPTION
This change adds ability to build diskimage-builder from source without
modifications of playbooks which use this role. Also contains revert of 
the previous PR with this feature.