### PR TITLE
Prevent use of openstacksdk 0.99.0 breaking compatibility

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,10 @@ os_images_package_state: present
 #
 # Use Train upper constraints when running with Python 2, to avoid
 # incompatibility with newer OSC releases.
-os_images_upper_constraints_file: "{% if ansible_facts.python.version.major == 2 %}https://releases.openstack.org/constraints/upper/train{% endif %}"
+# Use Train upper constraints when running with Python 2, to avoid
+# incompatibility with newer OSC releases. Use Yoga upper constraints
+# otherwise, to avoid incompatibility with openstacksdk 0.99.0.
+os_images_upper_constraints_file: "https://releases.openstack.org/constraints/upper/{% if ansible_python.version.major == 2 %}train{% else %}yoga{% endif %}"
 
 # Path to a directory in which to cache build artefacts.
 os_images_cache: "{{ lookup('env','HOME') }}/disk_images"


### PR DESCRIPTION
Version 0.99.0 of openstacksdk breaks various Ansible modules, including image upload.

Use yoga upper constraints to cap openstacksdk to 0.61.0.