### PR TITLE
Set loop label when iterating over os_images_list

### DIFF
--- a/tasks/images.yml
+++ b/tasks/images.yml
@@ -35,7 +35,7 @@
     state: absent
   when: item.force_rebuild | default(os_images_force_rebuild) | bool
   with_items: "{{ os_images_list }}"
-  loop_contol:
+  loop_control:
     label: "{{ item.name }}"
   tags: clean
 
@@ -46,7 +46,7 @@
     group: "{{ ansible_facts.user_gid }}"
     state: directory
   with_items: "{{ os_images_list }}"
-  loop_contol:
+  loop_control:
     label: "{{ item.name }}"
   become: True
 
@@ -57,13 +57,13 @@
         dest: "{{ image_dest }}"
         checksum: "{{ item.checksum | default(omit) }}"
       with_items: "{{ os_images_list }}"
-      loop_contol:
+      loop_control:
         label: "{{ item.name }}"
     - name: Unpack the image if .xz format
       command: unxz --keep --force {{ image_dest }}
       when: image_is_xz
       with_items: "{{ os_images_list }}"
-      loop_contol:
+      loop_control:
         label: "{{ item.name }}"
   vars:
     image_dest: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.{{ item.type | default('qcow2') }}{{ '.xz' if image_is_xz else '' }}"
@@ -120,7 +120,7 @@
     creates: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.d/dib-manifests"
   environment: "{{ os_image_dib_env_default | combine(item.env | default({})) }}"
   with_items: "{{ os_images_list }}"
-  loop_contol:
+  loop_control:
     label: "{{ item.name }}"
   failed_when: false
   register: result

--- a/tasks/images.yml
+++ b/tasks/images.yml
@@ -35,6 +35,8 @@
     state: absent
   when: item.force_rebuild | default(os_images_force_rebuild) | bool
   with_items: "{{ os_images_list }}"
+  loop_contol:
+    label: "{{ item.name }}"
   tags: clean
 
 - name: Generate per-image cache directories
@@ -44,6 +46,8 @@
     group: "{{ ansible_facts.user_gid }}"
     state: directory
   with_items: "{{ os_images_list }}"
+  loop_contol:
+    label: "{{ item.name }}"
   become: True
 
 - block:
@@ -53,10 +57,14 @@
         dest: "{{ image_dest }}"
         checksum: "{{ item.checksum | default(omit) }}"
       with_items: "{{ os_images_list }}"
+      loop_contol:
+        label: "{{ item.name }}"
     - name: Unpack the image if .xz format
       command: unxz --keep --force {{ image_dest }}
       when: image_is_xz
       with_items: "{{ os_images_list }}"
+      loop_contol:
+        label: "{{ item.name }}"
   vars:
     image_dest: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.{{ item.type | default('qcow2') }}{{ '.xz' if image_is_xz else '' }}"
     image_is_xz: "{{ item.image_url.endswith('.xz') }}"
@@ -112,6 +120,8 @@
     creates: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.d/dib-manifests"
   environment: "{{ os_image_dib_env_default | combine(item.env | default({})) }}"
   with_items: "{{ os_images_list }}"
+  loop_contol:
+    label: "{{ item.name }}"
   failed_when: false
   register: result
   # The output of this command can be quite large, and is not very useful as

--- a/tasks/upload.yml
+++ b/tasks/upload.yml
@@ -8,7 +8,7 @@
     name: "{{ item.name ~ '-kernel' }}"
     state: absent
   with_items: "{{ os_images_list }}"
-  loop_contol:
+  loop_control:
     label: "{{ item.name }}"
   when:
     - item.elements is defined
@@ -29,7 +29,7 @@
     disk_format: aki
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.vmlinuz"
   with_items: "{{ os_images_list }}"
-  loop_contol:
+  loop_control:
     label: "{{ item.name }}"
   when:
     - item.elements is defined
@@ -45,7 +45,7 @@
     name: "{{ item.name ~ '-ramdisk' }}"
     state: absent
   with_items: "{{ os_images_list }}"
-  loop_contol:
+  loop_control:
     label: "{{ item.name }}"
   when:
     - item.elements is defined
@@ -66,7 +66,7 @@
     disk_format: ari
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.initrd"
   with_items: "{{ os_images_list }}"
-  loop_contol:
+  loop_control:
     label: "{{ item.name }}"
   when:
     - item.elements is defined
@@ -82,7 +82,7 @@
     name: "{{ item.name }}"
     state: absent
   with_items: "{{ os_images_list }}"
-  loop_contol:
+  loop_control:
     label: "{{ item.name }}"
   when: item.force_rebuild | default(os_images_force_rebuild) | bool
   tags: clean
@@ -109,5 +109,5 @@
     - "{{ os_images_list }}"
     - "{{ kernel_result.results }}"
     - "{{ ramdisk_result.results }}"
-  loop_contol:
+  loop_control:
     label: "{{ item.0.name }}"

--- a/tasks/upload.yml
+++ b/tasks/upload.yml
@@ -8,6 +8,8 @@
     name: "{{ item.name ~ '-kernel' }}"
     state: absent
   with_items: "{{ os_images_list }}"
+  loop_contol:
+    label: "{{ item.name }}"
   when:
     - item.elements is defined
     - '"baremetal" in item.elements'
@@ -27,6 +29,8 @@
     disk_format: aki
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.vmlinuz"
   with_items: "{{ os_images_list }}"
+  loop_contol:
+    label: "{{ item.name }}"
   when:
     - item.elements is defined
     - '"baremetal" in item.elements'
@@ -41,6 +45,8 @@
     name: "{{ item.name ~ '-ramdisk' }}"
     state: absent
   with_items: "{{ os_images_list }}"
+  loop_contol:
+    label: "{{ item.name }}"
   when:
     - item.elements is defined
     - '"baremetal" in item.elements'
@@ -60,6 +66,8 @@
     disk_format: ari
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.initrd"
   with_items: "{{ os_images_list }}"
+  loop_contol:
+    label: "{{ item.name }}"
   when:
     - item.elements is defined
     - '"baremetal" in item.elements'
@@ -74,6 +82,8 @@
     name: "{{ item.name }}"
     state: absent
   with_items: "{{ os_images_list }}"
+  loop_contol:
+    label: "{{ item.name }}"
   when: item.force_rebuild | default(os_images_force_rebuild) | bool
   tags: clean
 
@@ -99,3 +109,5 @@
     - "{{ os_images_list }}"
     - "{{ kernel_result.results }}"
     - "{{ ramdisk_result.results }}"
+  loop_contol:
+    label: "{{ item.0.name }}"


### PR DESCRIPTION
This can potentially leak sensitive information e.g a devuser password.
Using the whole dictionary as the loop label is also very verbose.
You can easily map back to the definition using the name. It should be
noted that the `default` stdout callback plugin will still print the
image definition on failure[1]. You can get round this by using an
alternative callback plugin. You can't really set the loop label
in the callback plugin as you do not know which field to use for the label.

[1] https://serverfault.com/questions/1059530/how-to-not-print-items-in-an-ansible-loop-error-without-no-log