### PR TITLE
Removed upper constraints

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,7 @@ os_images_package_state: present
 # Use Train upper constraints when running with Python 2, to avoid
 # incompatibility with newer OSC releases. Use Yoga upper constraints
 # otherwise, to avoid incompatibility with openstacksdk 0.99.0.
-os_images_upper_constraints_file: "https://releases.openstack.org/constraints/upper/{% if ansible_facts.python.version.major == 2 %}train{% else %}yoga{% endif %}"
+os_images_upper_constraints_file: "https://releases.openstack.org/constraints/upper/{% if ansible_facts.python.version.major == 2 %}train{% else %}master{% endif %}"
 
 # Path to a directory in which to cache build artefacts.
 os_images_cache: "{{ lookup('env','HOME') }}/disk_images"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,11 +17,10 @@ os_images_package_state: present
 # Use Train upper constraints when running with Python 2, to avoid
 # incompatibility with newer OSC releases. Use Yoga upper constraints
 # otherwise, to avoid incompatibility with openstacksdk 0.99.0.
-# os_images_upper_constraints_file: "https://releases.openstack.org/constraints/upper/{% if ansible_facts.python.version.major == 2 %}train{% else %}master{% endif %}"
-os_images_upper_constraints_file: ""
+os_images_upper_constraints_file: "https://releases.openstack.org/constraints/upper/{% if ansible_facts.python.version.major == 2 %}train{% else %}master{% endif %}"
 
 # Upper constraints file for installation of DIB to build images.
-os_images_dib_upper_constraints_file: "{{ os_images_upper_constraints_file }}"
+os_images_dib_upper_constraints_file: ""
 
 # Path to a directory in which to cache build artefacts.
 os_images_cache: "{{ lookup('env','HOME') }}/disk_images"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,8 @@ os_images_package_state: present
 # Use Train upper constraints when running with Python 2, to avoid
 # incompatibility with newer OSC releases. Use Yoga upper constraints
 # otherwise, to avoid incompatibility with openstacksdk 0.99.0.
-os_images_upper_constraints_file: "https://releases.openstack.org/constraints/upper/{% if ansible_facts.python.version.major == 2 %}train{% else %}master{% endif %}"
+# os_images_upper_constraints_file: "https://releases.openstack.org/constraints/upper/{% if ansible_facts.python.version.major == 2 %}train{% else %}master{% endif %}"
+os_images_upper_constraints_file: ""
 
 # Path to a directory in which to cache build artefacts.
 os_images_cache: "{{ lookup('env','HOME') }}/disk_images"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,7 @@ os_images_package_state: present
 # Use Train upper constraints when running with Python 2, to avoid
 # incompatibility with newer OSC releases. Use Yoga upper constraints
 # otherwise, to avoid incompatibility with openstacksdk 0.99.0.
-os_images_upper_constraints_file: "https://releases.openstack.org/constraints/upper/{% if ansible_facts.python.version.major == 2 %}train{% else %}master{% endif %}"
+os_images_upper_constraints_file: "https://releases.openstack.org/constraints/upper/{% if ansible_facts.python.version.major == 2 %}train{% else %}yoga{% endif %}"
 
 # Upper constraints file for installation of DIB to build images.
 os_images_dib_upper_constraints_file: ""


### PR DESCRIPTION
Successful Rocky 9 image build depends on having the most recent version of DIB, in order for us to build new rocky9 images I needed to remove the upper constraints. I've tested all image builds and all of them are building properly without the constraints.