### PR TITLE
Add Rocky support

### DIFF
--- a/vars/Rocky.yml
+++ b/vars/Rocky.yml
@@ -1,0 +1,9 @@
+---
+# List of package dependencies.
+os_images_package_dependencies:
+  - dosfstools
+  - kpartx
+  - lvm2
+  - qemu-img
+  - squashfs-tools
+  - xz


### PR DESCRIPTION
Rocky hosts currently fail [here](https://github.com/stackhpc/ansible-role-os-images/blob/4696b3112d216c5cb2d871c6a98e91845a274147/tasks/images.yml#L3) as their os family is Rocky, not RedHat. 

This could also be resolved by changing the templating to be something like `{{ RedHat if family is Rocky else family }}`, but giving it a different file lets us change things separately if we need to.