### PR TITLE
Changes required for magnum 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ mutually exclusive where each contain:
   `os_images_force_rebuild`if left unset.
 * `is_public`: (optional) whether the image should be set as visible to all
   projects or kept private.
+* `visibility`: (optional) alternative to `is_public`. Allowed values are 'public', 'private', 
+or 'community'. 
 * `owner`: (optional) ID of the project that should own the uploaded image.
 
 `os_images_common`: A set of elements to include in every image listed.
@@ -96,6 +98,8 @@ will be replaced with the newly built image if `os_images_upload` is set to `Tru
 `False`.
 
 `os_images_public`: Whether uploaded images are public. Defaults to `True` - note this requires admin permissions.
+
+`os_images_visibility`: The visibility of images uploaded. Defaults to public/private, based off `os_images_public` - note this requires admin permissions.
 
 `os_images_venv`: Path to virtualenv in which to install python dependencies to upload images.
 

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ mutually exclusive where each contain:
   be built (even if an existing image that name has been built before). The images on glance
   will be replaced if `os_images_upload` is set to `True`. This defaults to
   `os_images_force_rebuild`if left unset.
-* `is_public`: (optional) whether the image should be set as visible to all
-  projects or kept private.
-* `visibility`: (optional) alternative to `is_public`. Allowed values are 'public', 'private', 
-or 'community'. 
+* `is_public`: (optional) (deprecated - use `visibility`) whether the image should be set as visible to all
+  projects or kept private. Note that if both `is_public` and `visibility` are provided, `is_public` will 
+  be preferred.
+* `visibility`: (optional) Allowed values are 'public', 'private', 'shared'
+or 'community'. Default is 'public'
 * `owner`: (optional) ID of the project that should own the uploaded image.
 
 `os_images_common`: A set of elements to include in every image listed.
@@ -97,7 +98,7 @@ following parameters:
 will be replaced with the newly built image if `os_images_upload` is set to `True`. Defaults to
 `False`.
 
-`os_images_public`: Whether uploaded images are public. Defaults to `True` - note this requires admin permissions.
+`os_images_public`: (Deprecated - use `os_images_visibility`) Whether uploaded images are public. Defaults to `True` - note this requires admin permissions. 
 
 `os_images_visibility`: The visibility of images uploaded. Defaults to public/private, based off `os_images_public` - note this requires admin permissions.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,7 @@ os_images_package_state: present
 # Use Train upper constraints when running with Python 2, to avoid
 # incompatibility with newer OSC releases. Use Yoga upper constraints
 # otherwise, to avoid incompatibility with openstacksdk 0.99.0.
-os_images_upper_constraints_file: "https://releases.openstack.org/constraints/upper/{% if ansible_facts.python.version.major == 2 %}train{% else %}yoga{% endif %}"
+os_images_upper_constraints_file: "https://releases.openstack.org/constraints/upper/2023.1"
 
 # Upper constraints file for installation of DIB to build images.
 os_images_dib_upper_constraints_file: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -93,6 +93,9 @@ os_images_force_rebuild: False
 # Whether images should be public (requires admin rights)
 os_images_public: True
 
+# Visibility of images ('public' requires admin rights.)
+os_images_visibility: "{{ 'public' if os_images_public else 'private' }}"
+
 # Whether or not should old images be retired and new images be promoted
 os_images_promote: False
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,9 +26,9 @@ dependencies:
   - role: stackhpc.os_openstacksdk
     os_openstacksdk_venv: "{{ os_images_venv }}"
     os_openstacksdk_state: "{{ os_images_package_state }}"
-    os_openstacksdk_upper_constraints_file: "{{ os_images_upper_constraints_file }}"
+    os_openstacksdk_version: "1.0"
 
   - role: stackhpc.os-openstackclient
     os_openstackclient_venv: "{{ os_images_venv }}"
     os_openstackclient_state: "{{ os_images_package_state }}"
-    os_openstackclient_upper_constraints_file: "{{ os_images_upper_constraints_file }}"
+    os_openstackclient_version: "6.2.0"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,9 +26,9 @@ dependencies:
   - role: stackhpc.os_openstacksdk
     os_openstacksdk_venv: "{{ os_images_venv }}"
     os_openstacksdk_state: "{{ os_images_package_state }}"
-    os_openstacksdk_version: "1.0"
+    os_openstacksdk_upper_constraints_file: "{{ os_images_upper_constraints_file }}"
 
   - role: stackhpc.os-openstackclient
     os_openstackclient_venv: "{{ os_images_venv }}"
     os_openstackclient_state: "{{ os_images_package_state }}"
-    os_openstackclient_version: "6.2.0"
+    os_openstacksdk_upper_constraints_file: "{{ os_images_upper_constraints_file }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,4 +14,17 @@
 - import_tasks: promote.yml
   vars:
     ansible_python_interpreter: "{{ os_images_venv ~ '/bin/python' if os_images_venv != None else old_ansible_python_interpreter }}"
-  when: os_images_promote | bool
+  when: >
+    (
+      (
+        os_images_list |
+        selectattr('rename_image', 'defined')
+      ) +
+      (
+        os_images_list |
+        selectattr('hide_image', 'defined')
+      )
+    ) |
+    list | length > 0
+    or (os_images_promote | bool)
+    or (os_images_hide | bool)

--- a/tasks/promote.yml
+++ b/tasks/promote.yml
@@ -7,11 +7,12 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
   register: retire_or_promote_list
   when: >
-       (os_images_list | 
-        selectattr('rename_image', 'defined') |
-        selectattr('rename_image', 'equalto', true) |
-        list | length > 0)
-        or (os_images_promote | bool)
+    (
+      (os_images_list |
+      selectattr('rename_image', 'defined') |
+      list | length > 0)
+      or (os_images_promote | bool)
+    )
 
 - name: Ensure images for retirement exist
   assert:
@@ -33,13 +34,13 @@
 
 - name: Check if image suffix is provided
   set_fact:
-    image_suffix_provided: "{{ os_images_name_suffix is defined and os_images_name_suffix | length == 0 | bool }}"
+    image_suffix_provided: "{{ os_images_name_suffix is defined and os_images_name_suffix is not none and (os_images_name_suffix | length > 0) | bool }}"
 
-- debug: 
+- debug:
     msg: |
       Warning: no image suffix is provided so retired images are not renamed and candidate images are not promoted.
-      Images with the `hide_image` attribute will still be hidden. 
-  when: image_suffix_provided is False
+      Images with the `hide_image` attribute will still be hidden.
+  when: image_suffix_provided == false
 
 - name: Hide retire candidate images
   command: "{{ os_images_venv }}/bin/openstack image set --hidden {{ promotion_name }}"
@@ -75,9 +76,11 @@
       The following images have been promoted: 
       {% for item in images %}
       {{ item.name }} > {{ item.name[:-(os_images_name_suffix | length | int)] }}
+      {% endfor %}
   vars:
     images: "{{ os_images_list | list }}"
+  when: image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)
 
 - debug:
     var: renaming_message
-  when: "image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)"
+  when: image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)

--- a/tasks/promote.yml
+++ b/tasks/promote.yml
@@ -1,49 +1,57 @@
 ---
-- name: Check if image suffix is provided
-  fail:
-    msg: "os_images_name_suffix is empty please provide it."
-  when: os_images_name_suffix is defined and os_images_name_suffix | length == 0
-
-- name: Gather retire candidates info
+- name: Gather candidates info
   openstack.cloud.image_info:
     auth_type: "{{ os_images_auth_type }}"
     auth: "{{ os_images_auth }}"
     cacert: "{{ os_images_cacert | default(omit) }}"
     interface: "{{ os_images_interface | default(omit, true) }}"
-  register: retire_list
-  when: item.rename_image | default(os_images_promote) | bool
+  register: retire_or_promote_list
+  when: >
+       (os_images_list | 
+        selectattr('rename_image', 'defined') |
+        selectattr('rename_image', 'equalto', true) |
+        list | length > 0)
+        or (os_images_promote | bool)
 
 - name: Ensure images for retirement exist
   assert:
     that:
-      - item.name in retire_list.openstack_images | map(attribute='name') | list
+      - promotion_name in retire_or_promote.openstack_images | map(attribute='name') | list
     fail_msg: "The image {{ item.name[:-(os_images_name_suffix | length | int)] }} does not exist."
+  vars:
+    promotion_name: "{{ item.name[:-(os_images_name_suffix | length | int)] }}"
   loop: "{{ os_images_list | list }}"
-  when: item.rename_image | default(os_images_promote) | bool
-
-- name: Gather promote candidates info
-  openstack.cloud.image_info:
-    auth_type: "{{ os_images_auth_type }}"
-    auth: "{{ os_images_auth }}"
-    cacert: "{{ os_images_cacert | default(omit) }}"
-    interface: "{{ os_images_interface | default(omit, true) }}"
-  register: promote_list
   when: item.rename_image | default(os_images_promote) | bool
 
 - name: Ensure images for promotion exist
   assert:
     that:
-      - item.name in promote_list.openstack_images | map(attribute='name') | list
+      - item.name in retire_or_promote_list.openstack_images | map(attribute='name') | list
     fail_msg: "The image {{ item.name }} does not exist."
   loop: "{{ os_images_list | list }}"
   when: item.rename_image | default(os_images_promote) | bool
 
+- name: Set community images
+  command: "{{ os_images_venv }}/bin/openstack image set --community {{ item.name }}"
+  loop: "{{ os_images_list | list }}"
+  when: item.visiblility == 'community'
+
+- name: Check if image suffix is provided
+  set_fact:
+    image_suffix_provided: "{{ os_images_name_suffix is defined and os_images_name_suffix | length == 0 | bool }}"
+
+- debug: 
+    msg: |
+      Warning: no image suffix is provided so retired images are not renamed and candidate images are not promoted.
+      Images with the `hide_image` attribute will still be hidden. 
+  when: image_suffix_provided is False
+
 - name: Hide retire candidate images
   command: "{{ os_images_venv }}/bin/openstack image set --hidden {{ promotion_name }}"
   vars:
-    promotion_name: "{{ item.name[:-(os_images_name_suffix | length | int)] }}"
+    promotion_name: "{{ item.name[:-(os_images_name_suffix | length | int)] if image_suffix_provided else item.name }}"
   with_items: "{{ os_images_list | list }}"
-  when: (item.rename_image | default(os_images_promote) | bool) and (item.hide_image | default(os_images_hide) | bool)
+  when: (item.hide_image | default(os_images_hide) | bool)
 
 - name: Ensure old images are retired
   command: "{{ os_images_venv }}/bin/openstack image set {{ promotion_name }} --name {{ promotion_name }}.{{ date_suffix }}"
@@ -51,7 +59,7 @@
     date_suffix: "{{ ansible_date_time.date }}"
     promotion_name: "{{ item.name[:-(os_images_name_suffix | length | int)] }}"
   loop: "{{ os_images_list | list }}"
-  when: "item.rename_image | default(os_images_promote) | bool"
+  when: "image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)"
   environment: "{{ os_images_venv }}"
 
 - name: Ensure new images are promoted
@@ -59,5 +67,22 @@
   vars:
     promotion_name: "{{ item.name[:-(os_images_name_suffix | length | int)] }}"
   loop: "{{ os_images_list | list }}"
-  when: "item.rename_image | default(os_images_promote) | bool"
+  when: "image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)"
   environment: "{{ os_images_venv }}"
+
+- name: Discover renamed images
+  set_fact:
+    renaming_message: |
+      The following images have been retired:
+      {% for item in images %}
+      {{ item.name[:-(os_images_name_suffix | length | int)] }} > {{ item.name[:-(os_images_name_suffix | length | int)] }}.{{ ansible_date_time.date }}
+      {% endfor %}
+      The following images have been promoted: 
+      {% for item in images %}
+      {{ item.name }} > {{ item.name[:-(os_images_name_suffix | length | int)] }}
+  vars:
+    images: "{{ os_images_list | list }}"
+
+- debug:
+    var: renaming_message
+  when: "image_suffix_provided and (item.rename_image | default(os_images_promote) | bool)"

--- a/tasks/promote.yml
+++ b/tasks/promote.yml
@@ -31,11 +31,6 @@
   loop: "{{ os_images_list | list }}"
   when: item.rename_image | default(os_images_promote) | bool
 
-- name: Set community images
-  command: "{{ os_images_venv }}/bin/openstack image set --community {{ item.name }}"
-  loop: "{{ os_images_list | list }}"
-  when: item.visiblility == 'community' | default(os_images_visibility == 'community')
-
 - name: Check if image suffix is provided
   set_fact:
     image_suffix_provided: "{{ os_images_name_suffix is defined and os_images_name_suffix | length == 0 | bool }}"

--- a/tasks/promote.yml
+++ b/tasks/promote.yml
@@ -34,7 +34,7 @@
 - name: Set community images
   command: "{{ os_images_venv }}/bin/openstack image set --community {{ item.name }}"
   loop: "{{ os_images_list | list }}"
-  when: item.visiblility == 'community'
+  when: item.visiblility == 'community' | default(os_images_visibility == 'community')
 
 - name: Check if image suffix is provided
   set_fact:

--- a/tasks/upload.yml
+++ b/tasks/upload.yml
@@ -22,7 +22,7 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
     name: "{{ item.name ~ '-kernel' }}"
     state: present
-    is_public: "{{ (item.is_public or item.visibility == 'public') | default(os_images_public) | bool }}"
+    is_public: "{{ (item.is_public or item.visibility == 'public') | default(os_images_visibility == 'public') | bool }}"
     container_format: aki
     disk_format: aki
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.vmlinuz"
@@ -55,7 +55,7 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
     name: "{{ item.name ~ '-ramdisk' }}"
     state: present
-    is_public: "{{ (item.is_public or item.visibility == 'public') | default(os_images_public) | bool }}"
+    is_public: "{{ (item.is_public or item.visibility == 'public') | default(os_images_visibility == 'public') | bool }}"
     container_format: ari
     disk_format: ari
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.initrd"
@@ -85,7 +85,7 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
     name: "{{ item.0.name }}"
     state: present
-    is_public: "{{ (item.0.is_public or item.0.visibility == 'public') | default(os_images_public) | bool }}"
+    is_public: "{{ (item.0.is_public or item.0.visibility == 'public') | default(os_images_visibility == 'public') | bool }}"
     owner: "{{ item.0.owner | default(omit) }}"
     container_format: bare
     disk_format: "{{ item.0.type | default('qcow2') }}"

--- a/tasks/upload.yml
+++ b/tasks/upload.yml
@@ -22,7 +22,7 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
     name: "{{ item.name ~ '-kernel' }}"
     state: present
-    is_public: "{{ item.is_public | item.visibility == 'public' | default(os_images_public) | bool }}"
+    is_public: "{{ (item.is_public or item.visibility == 'public') | default(os_images_public) | bool }}"
     container_format: aki
     disk_format: aki
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.vmlinuz"
@@ -55,7 +55,7 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
     name: "{{ item.name ~ '-ramdisk' }}"
     state: present
-    is_public: "{{ item.is_public | item.visibility == 'public' | default(os_images_public) | bool }}"
+    is_public: "{{ (item.is_public or item.visibility == 'public') | default(os_images_public) | bool }}"
     container_format: ari
     disk_format: ari
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.initrd"
@@ -85,7 +85,7 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
     name: "{{ item.0.name }}"
     state: present
-    is_public: "{{ item.0.is_public | item.0.visibility == 'public' | default(os_images_public) | bool }}"
+    is_public: "{{ (item.0.is_public or item.0.visibility == 'public') | default(os_images_public) | bool }}"
     owner: "{{ item.0.owner | default(omit) }}"
     container_format: bare
     disk_format: "{{ item.0.type | default('qcow2') }}"

--- a/tasks/upload.yml
+++ b/tasks/upload.yml
@@ -22,7 +22,7 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
     name: "{{ item.name ~ '-kernel' }}"
     state: present
-    is_public: "{{ item.visibility == 'public' | default(os_images_public) | bool }}"
+    is_public: "{{ item.is_public | item.visibility == 'public' | default(os_images_public) | bool }}"
     container_format: aki
     disk_format: aki
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.vmlinuz"
@@ -55,7 +55,7 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
     name: "{{ item.name ~ '-ramdisk' }}"
     state: present
-    is_public: "{{ item.visibility == 'public' | default(os_images_public) | bool }}"
+    is_public: "{{ item.is_public | item.visibility == 'public' | default(os_images_public) | bool }}"
     container_format: ari
     disk_format: ari
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.initrd"
@@ -85,7 +85,7 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
     name: "{{ item.0.name }}"
     state: present
-    is_public: "{{ item.0.visibility == 'public' | default(os_images_public) | bool }}"
+    is_public: "{{ item.0.is_public | item.0.visibility == 'public' | default(os_images_public) | bool }}"
     owner: "{{ item.0.owner | default(omit) }}"
     container_format: bare
     disk_format: "{{ item.0.type | default('qcow2') }}"

--- a/tasks/upload.yml
+++ b/tasks/upload.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure existing cloud tenant kernel does not exist
-  os_image:
+  openstack.cloud.image:
     auth_type: "{{ os_images_auth_type }}"
     auth: "{{ os_images_auth }}"
     cacert: "{{ os_images_cacert | default(omit) }}"
@@ -15,7 +15,7 @@
   tags: clean
 
 - name: Upload cloud tenant kernel for baremetal images
-  os_image:
+  openstack.cloud.image:
     auth_type: "{{ os_images_auth_type }}"
     auth: "{{ os_images_auth }}"
     cacert: "{{ os_images_cacert | default(omit) }}"
@@ -35,7 +35,7 @@
   register: kernel_result
 
 - name: Ensure existing cloud tenant ramdisk does not exist
-  os_image:
+  openstack.cloud.image:
     auth_type: "{{ os_images_auth_type }}"
     auth: "{{ os_images_auth }}"
     cacert: "{{ os_images_cacert | default(omit) }}"
@@ -50,7 +50,7 @@
   tags: clean
 
 - name: Upload cloud tenant ramdisk for baremetal images
-  os_image:
+  openstack.cloud.image:
     auth_type: "{{ os_images_auth_type }}"
     auth: "{{ os_images_auth }}"
     cacert: "{{ os_images_cacert | default(omit) }}"
@@ -70,7 +70,7 @@
   register: ramdisk_result
 
 - name: Ensure existing cloud tenant image does not exist
-  os_image:
+  openstack.cloud.image:
     auth_type: "{{ os_images_auth_type }}"
     auth: "{{ os_images_auth }}"
     cacert: "{{ os_images_cacert | default(omit) }}"
@@ -82,7 +82,7 @@
   tags: clean
 
 - name: Upload cloud tenant images
-  os_image:
+  openstack.cloud.image:
     auth_type: "{{ os_images_auth_type }}"
     auth: "{{ os_images_auth }}"
     cacert: "{{ os_images_cacert | default(omit) }}"

--- a/tasks/upload.yml
+++ b/tasks/upload.yml
@@ -22,7 +22,7 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
     name: "{{ item.name ~ '-kernel' }}"
     state: present
-    is_public: "{{ item.is_public | default(os_images_public) | bool }}"
+    is_public: "{{ item.visibility == 'public' | default(os_images_public) | bool }}"
     container_format: aki
     disk_format: aki
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.vmlinuz"
@@ -55,7 +55,7 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
     name: "{{ item.name ~ '-ramdisk' }}"
     state: present
-    is_public: "{{ item.is_public | default(os_images_public) | bool }}"
+    is_public: "{{ item.visibility == 'public' | default(os_images_public) | bool }}"
     container_format: ari
     disk_format: ari
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.initrd"
@@ -85,7 +85,7 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
     name: "{{ item.0.name }}"
     state: present
-    is_public: "{{ item.0.is_public | default(os_images_public) | bool }}"
+    is_public: "{{ item.0.visibility == 'public' | default(os_images_public) | bool }}"
     owner: "{{ item.0.owner | default(omit) }}"
     container_format: bare
     disk_format: "{{ item.0.type | default('qcow2') }}"

--- a/tasks/upload.yml
+++ b/tasks/upload.yml
@@ -22,11 +22,13 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
     name: "{{ item.name ~ '-kernel' }}"
     state: present
-    is_public: "{{ (item.is_public or item.visibility == 'public') | default(os_images_visibility == 'public') | bool }}"
+    visibility: "{{ visibility | default(os_images_visibility) | bool }}"
     container_format: aki
     disk_format: aki
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.vmlinuz"
   with_items: "{{ os_images_list | list }}"
+  vars: 
+    visibility: "{{ 'public' if item.is_public else 'private' if item.is_public == False else item.visibility }}"
   when:
     - item.elements is defined
     - '"baremetal" in item.elements'
@@ -55,11 +57,13 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
     name: "{{ item.name ~ '-ramdisk' }}"
     state: present
-    is_public: "{{ (item.is_public or item.visibility == 'public') | default(os_images_visibility == 'public') | bool }}"
+    visibility: "{{ visibility | default(os_images_visibility) | bool }}"
     container_format: ari
     disk_format: ari
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.initrd"
   with_items: "{{ os_images_list | list }}"
+  vars: 
+    visibility: "{{ 'public' if item.is_public else 'private' if item.is_public == False else item.visibility }}"
   when:
     - item.elements is defined
     - '"baremetal" in item.elements'
@@ -85,7 +89,7 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
     name: "{{ item.0.name }}"
     state: present
-    is_public: "{{ (item.0.is_public or item.0.visibility == 'public') | default(os_images_visibility == 'public') | bool }}"
+    visibility: "{{ visibility | default(os_images_visibility) | bool }}"
     owner: "{{ item.0.owner | default(omit) }}"
     container_format: bare
     disk_format: "{{ item.0.type | default('qcow2') }}"
@@ -95,6 +99,7 @@
     ramdisk: "{{ item.2.id if is_baremetal else omit }}"
   vars:
     is_baremetal: "{{ item.0.elements is defined and 'baremetal' in item.0.elements }}"
+    visibility: "{{ 'public' if item.0.is_public else 'private' if item.0.is_public == False else item.0.visibility }}"
   with_together:
     - "{{ os_images_list | list }}"
     - "{{ kernel_result.results }}"

--- a/tasks/upload.yml
+++ b/tasks/upload.yml
@@ -22,13 +22,13 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
     name: "{{ item.name ~ '-kernel' }}"
     state: present
-    visibility: "{{ visibility | default(os_images_visibility) | bool }}"
+    visibility: "{{ visibility | default(os_images_visibility) }}"
     container_format: aki
     disk_format: aki
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.vmlinuz"
   with_items: "{{ os_images_list | list }}"
   vars: 
-    visibility: "{{ 'public' if item.is_public else 'private' if item.is_public == False else item.visibility }}"
+    visibility: "{{ item.visibility | default(item.is_public | ternary('public', 'private') if item.is_public is defined else os_images_visibility) }}"
   when:
     - item.elements is defined
     - '"baremetal" in item.elements'
@@ -57,13 +57,13 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
     name: "{{ item.name ~ '-ramdisk' }}"
     state: present
-    visibility: "{{ visibility | default(os_images_visibility) | bool }}"
+    visibility: "{{ visibility | default(os_images_visibility) }}"
     container_format: ari
     disk_format: ari
     filename: "{{ os_images_cache }}/{{ item.name }}/{{ item.name }}.initrd"
   with_items: "{{ os_images_list | list }}"
   vars: 
-    visibility: "{{ 'public' if item.is_public else 'private' if item.is_public == False else item.visibility }}"
+    visibility: "{{ item.visibility | default(item.is_public | ternary('public', 'private') if item.is_public is defined else os_images_visibility) }}"
   when:
     - item.elements is defined
     - '"baremetal" in item.elements'
@@ -89,7 +89,7 @@
     interface: "{{ os_images_interface | default(omit, true) }}"
     name: "{{ item.0.name }}"
     state: present
-    visibility: "{{ visibility | default(os_images_visibility) | bool }}"
+    visibility: "{{ visibility | default(os_images_visibility) }}"
     owner: "{{ item.0.owner | default(omit) }}"
     container_format: bare
     disk_format: "{{ item.0.type | default('qcow2') }}"
@@ -99,7 +99,7 @@
     ramdisk: "{{ item.2.id if is_baremetal else omit }}"
   vars:
     is_baremetal: "{{ item.0.elements is defined and 'baremetal' in item.0.elements }}"
-    visibility: "{{ 'public' if item.0.is_public else 'private' if item.0.is_public == False else item.0.visibility }}"
+    visibility: "{{ item.0.visibility | default(item.0.is_public | ternary('public', 'private') if item.0.is_public is defined else os_images_visibility) }}"
   with_together:
     - "{{ os_images_list | list }}"
     - "{{ kernel_result.results }}"


### PR DESCRIPTION
The following changes enable our kubernetes images to be deployed and retired as part of the new magnum/azimuth image and template pipeline: 
- the `is_public` property is deprecated, and a `visibility` property is added, which allows for images to be public, private, community or shared (although nothing is done if `shared` is used at the moment, it will be set to private). if `visibility` is not set, the image will default to public, the same as before. 
- images can be hidden even if there is no renaming to be done. This is the case for kubernetes images, as there are no release candidates because images are tested before uploading, but old images do need to be hidden. The behaviour for the previous retire/promote workflow remains the same. 

Additionally some duplication is removed, the check for whether images to be retired exist has been fixed (I think), and some output at the end of the run detailing which images have been promoted or retired is given, which might be useful to verify if any mistakes were made.
